### PR TITLE
Add session variable grammar

### DIFF
--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -512,7 +512,7 @@ static Node *makeRecursiveViewSelect(char *relname, List *aliases, Node *query);
 %type <node>	def_arg columnElem where_clause where_or_current_clause
 				a_expr b_expr c_expr AexprConst indirection_el opt_slice_bound
 				columnref in_expr having_clause func_table xmltable array_expr
-				OptWhereClause operator_def_arg
+				OptWhereClause operator_def_arg session_var_name_ref
 %type <list>	opt_column_and_period_list
 %type <list>	rowsfrom_item rowsfrom_list opt_col_def_list
 %type <boolean> opt_ordinality opt_without_overlaps
@@ -2059,6 +2059,13 @@ sessionVariableDef:
                     n->name = $1;
                     n->expr = $3;
                     $$ = (Node *) n;
+                }
+        ;
+
+session_var_name_ref:
+            SESSION_VAR_NAME
+                {
+                    $$ = makeColumnRef($1, NIL, @1, yyscanner);
                 }
         ;
 
@@ -15415,6 +15422,7 @@ b_expr:		c_expr
  * ambiguity to the b_expr syntax.
  */
 c_expr:		columnref								{ $$ = $1; }
+            | session_var_name_ref                  { $$ = $1; }
 			| AexprConst							{ $$ = $1; }
 			| PARAM opt_indirection
 				{

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -673,7 +673,7 @@ static Node *makeRecursiveViewSelect(char *relname, List *aliases, Node *query);
  * DOT_DOT is unused in the core SQL grammar, and so will always provoke
  * parse errors.  It is needed by PL/pgSQL.
  */
-%token <str>	IDENT UIDENT FCONST SCONST USCONST BCONST XCONST Op
+%token <str>	IDENT UIDENT FCONST SCONST USCONST BCONST XCONST Op SESSION_VAR_NAME
 %token <ival>	ICONST PARAM
 %token			TYPECAST DOT_DOT COLON_EQUALS EQUALS_GREATER
 %token			LESS_EQUALS GREATER_EQUALS NOT_EQUALS

--- a/src/backend/parser/scan.l
+++ b/src/backend/parser/scan.l
@@ -436,6 +436,7 @@ integer_junk	{decinteger}{identifier}
 numeric_junk	{numeric}{identifier}
 real_junk		{real}{identifier}
 param_junk		\${decdigit}+{identifier}
+session_var     @{identifier}
 
 other			.
 
@@ -453,6 +454,11 @@ other			.
  */
 
 %%
+
+{session_var}   {
+                    yylval->str = pstrdup(yytext);
+                    return SESSION_VAR_NAME;
+                }
 
 {whitespace}	{
 					/* ignore */

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -2669,7 +2669,7 @@ typedef struct sessionVariableDef
     NodeTag		type;
     char	   *name;
     Node       *expr;
-} SessionVariableDef;
+} sessionVariableDef;
 
 typedef struct SessionVariableStmt
 {

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -2660,6 +2660,24 @@ typedef struct VariableShowStmt
 } VariableShowStmt;
 
 /* ----------------------
+ * SET session variable
+ * ----------------------
+ */
+
+typedef struct sessionVariableDef
+{
+    NodeTag		type;
+    char	   *name;
+    Node       *expr;
+} SessionVariableDef;
+
+typedef struct SessionVariableStmt
+{
+    NodeTag		type;
+    List	   *variables; /* List of sessionVariableDef */
+} SessionVariableStmt;
+
+/* ----------------------
  *		Create Table Statement
  *
  * NOTE: in the raw gram.y output, ColumnDef and Constraint nodes are


### PR DESCRIPTION
Main grammar rules for seting the session variable. Only syntax currently missing is `SELECT @varname := expr`